### PR TITLE
BACKLOG-22417: Remove MaxPermSize JVM option

### DIFF
--- a/src/lib/com/izforge/izpack/uninstaller/SelfModifier.java
+++ b/src/lib/com/izforge/izpack/uninstaller/SelfModifier.java
@@ -462,7 +462,7 @@ public class SelfModifier
         List<String> command = new ArrayList<String>();
         command.add(javaCommand);
         command.add("-Xmx" + this.maxmemory + "m");
-        command.add("-XX:MaxPermSize=" + maxpermgensize + "m");
+        // command.add("-XX:MaxPermSize=" + maxpermgensize + "m"); // invalid for jvm 17; remove
 // activate for debugging purposes.        
 //        command.add("-Xdebug");        
 //        int debugPort = 8000 + nextPhase;        


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22417

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Remove JVM option `-XX:MaxPermSize` to be able to run uninstaller with jvm 17.